### PR TITLE
Add universal site support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 [![unnamed](./thumbnail.png)](https://chromewebstore.google.com/detail/scroll-minimap-for-chatgp/apekbedjllgmacohbcckgipfhjddehkf) | <video src="https://github.com/user-attachments/assets/94334603-5427-4b6b-ac43-bcaf29288da3.mp4" />
 -|-
 
-I made this extension because I kept getting lost during my conversations with chatgpt. Sometimes chatgpt be giving you alot of useless info you didnt ask for. Navigating through what it says and finding the useful bits can be pretty tedious. This extension aims to solve that.
+I made this extension because I kept getting lost during my conversations with chatgpt. Sometimes chatgpt be giving you alot of useless info you didnt ask for. Navigating through what it says and finding the useful bits can be pretty tedious. This extension aims to solve that. It now works on any website you choose, not just ChatGPT.
 
 ## Usage
 1. Download the extension from [Chrome web store](https://chromewebstore.google.com/detail/scroll-minimap-for-chatgp/apekbedjllgmacohbcckgipfhjddehkf)
 
 2. Restart chrome
 
-3. Go to chatgpt, you should see a toggle button for the minimap in the top right corner. Open the minimap by pressing this button.
+3. Visit any website. Open the extension popup and enable the minimap for that site.
 
-4. Ask chatgpt a message and hit refresh minimap. A condensed view of the conversation should be shown in the minimap.
+4. If enabled, a minimap toggle will appear in the top right. Refresh the minimap to generate an overview of the page.
 
 
 ## Performace improvement

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -15,7 +15,7 @@
     "content_scripts": [
         {
             "matches": [
-                "https://chatgpt.com/*"
+                "<all_urls>"
             ],
             "js": [
                 "content/content.js"
@@ -28,7 +28,6 @@
     "web_accessible_resources": [
         {
           "resources": ["assets/logo.png"],
-          "matches": ["https://chatgpt.com/*"]
+          "matches": ["<all_urls>"]
         }
-    ]
-}
+    ]}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,5 +4,5 @@ export const DEFAULT_OPTIONS: ExtensionOptions = {
     keepOpen: false,
     smoothScrolling: true,
     autoRefresh: false,
-    refreshPeriod: 10
-}
+    refreshPeriod: 10,
+    allowedSites: ["chatgpt.com"]}

--- a/src/features/content/ContentContainer/ContentContainer.tsx
+++ b/src/features/content/ContentContainer/ContentContainer.tsx
@@ -10,6 +10,9 @@ export default function ContentContainer() {
   const [currentUrl, setCurrentUrl] = useState<string>("")
   const [currentScrollContainer, setCurrentScrollContainer] = useState<HTMLElement|null>(null)
   const [showButton, setShowButton] = useState<boolean>(true)
+  const [isSiteEnabled, setIsSiteEnabled] = useState<boolean>(false)
+
+  const isChatGPT = location.hostname.includes("chatgpt.com") || location.hostname.includes("chat.openai.com")
 
   // functions
   function updateCurrentUrl() {
@@ -21,6 +24,12 @@ export default function ContentContainer() {
   }
 
   async function searchForChat(): Promise<null> {
+    const isChatGPT = location.hostname.includes("chatgpt.com") || location.hostname.includes("chat.openai.com")
+    if (!isChatGPT) {
+      setCurrentScrollContainer(document.documentElement)
+      return null
+    }
+
     await delay(500)
     for (let i =0; i<10; i++) {
       const chat = queryChatContainer()
@@ -43,19 +52,33 @@ export default function ContentContainer() {
         setShowButton(result.showButton);
       }
     });
+    chrome.storage.local.get("enabledSites", (result) => {
+      const host = location.hostname.replace(/^www\./, "")
+      const sites = result.enabledSites || ["chatgpt.com"]
+      if (!result.enabledSites) {
+        chrome.storage.local.set({ enabledSites: sites })
+      }
+      setIsSiteEnabled(sites.includes(host))
+    })
   }, [])
 
   // On current url change
   useEffect(() => {
-    // console.log("current url", currentUrl.slice(-2))
     searchForChat()
+    chrome.storage.local.get("enabledSites", (result) => {
+      const host = location.hostname.replace(/^www\./, "")
+      const sites = result.enabledSites || ["chatgpt.com"]
+      setIsSiteEnabled(sites.includes(host))
+    })
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUrl])
 
   return (
- 
+
       <div className={styles.appContainer}>
-        {showButton && <Minimap elementToMap={currentScrollContainer}/>}
+        {showButton && isSiteEnabled && (
+          <Minimap elementToMap={currentScrollContainer} isFullHtml={!isChatGPT} />
+        )}
       </div>
 
   );

--- a/src/features/popup/App.tsx
+++ b/src/features/popup/App.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react'
 
 function App() {
   const [showButton, setShowButton] = useState(true)
+  const [siteEnabled, setSiteEnabled] = useState(true)
 
   function toggleShowButton(newValue: boolean) {
     setShowButton(newValue)
@@ -21,6 +22,28 @@ function App() {
 
   }
 
+  function toggleSiteEnabled(newValue: boolean) {
+    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+      const currentTabID = tabs[0].id
+      const url = tabs[0].url ? new URL(tabs[0].url) : null
+      if (!url) return
+      const host = url.hostname.replace(/^www\./, "")
+      chrome.storage.local.get("enabledSites", (result) => {
+        const sites: string[] = result.enabledSites || ["chatgpt.com"]
+        let updated = sites
+        if (newValue) {
+          if (!sites.includes(host)) updated = [...sites, host]
+        } else {
+          updated = sites.filter((s) => s !== host)
+        }
+        chrome.storage.local.set({ enabledSites: updated }, () => {
+          setSiteEnabled(newValue)
+          if (currentTabID) chrome.tabs.reload(currentTabID)
+        })
+      })
+    })
+  }
+
 
   useEffect(() => {
     chrome.storage.local.get("showButton", (result) => {
@@ -28,6 +51,18 @@ function App() {
         setShowButton(result.showButton);
       }
     });
+    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+      const url = tabs[0].url ? new URL(tabs[0].url) : null
+      if (!url) return
+      const host = url.hostname.replace(/^www\./, "")
+      chrome.storage.local.get("enabledSites", (result) => {
+        const sites: string[] = result.enabledSites || ["chatgpt.com"]
+        if (!result.enabledSites) {
+          chrome.storage.local.set({ enabledSites: sites })
+        }
+        setSiteEnabled(sites.includes(host))
+      })
+    })
   }, []);
 
 
@@ -46,12 +81,7 @@ function App() {
       <div className={styles.body}>
 
         <div>
-          This extension only works for <a
-            href="https://www.chatgpt.com"
-            target="_blank"
-          >
-            chatgpt.com
-          </a>
+          Enable the minimap on any website using the toggle below.
         </div>
 
         <div className={styles.demo}>
@@ -91,6 +121,20 @@ function App() {
             type="checkbox"
             checked={!showButton}
           // onChange={(e) => setShowButton(e.target.checked)}
+          />
+
+        </div>
+        <div
+          className={styles.checkbox}
+          onClick={() => toggleSiteEnabled(!siteEnabled)}
+        >
+          <label>
+            Enable on this site
+          </label>
+
+          <input
+            type="checkbox"
+            checked={siteEnabled}
           />
 
         </div>

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -2,5 +2,5 @@ export interface ExtensionOptions {
     keepOpen: boolean,
     smoothScrolling: boolean,
     autoRefresh: boolean,
-    refreshPeriod: number
-}
+    refreshPeriod: number,
+    allowedSites: string[]}


### PR DESCRIPTION
## Summary
- support all websites via `<all_urls>` content script
- add allowedSites to stored options
- let users enable the minimap on current site from the popup
- allow mapping the full page when not on ChatGPT
- update README for new functionality

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e1a1c63e08327a429faf70315aacd