### PR TITLE
Enable minimap on any site

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ I made this extension because I kept getting lost during my conversations with c
 
 2. Restart chrome
 
-3. Go to chatgpt, you should see a toggle button for the minimap in the top right corner. Open the minimap by pressing this button.
+3. By default the minimap is enabled on `chatgpt.com`. Open the extension popup to add domains or use `*` to enable it everywhere.
 
-4. Ask chatgpt a message and hit refresh minimap. A condensed view of the conversation should be shown in the minimap.
+4. Navigate to a supported site and you should see a toggle button for the minimap in the top right corner. Ask chatgpt or other sites a message and hit refresh minimap if required.
 
 
 ## Performace improvement

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -2,12 +2,15 @@
     "manifest_version": 3,
     "name": "Chat GPT Scroll Map",
     "version": "1.5.2",
-    "description": "A minimap for scrolling through chat gpt messages, similar to the one in VS Code",
+    "description": "A minimap for scrolling through webpages, similar to the one in VS Code",
     "icons": {
         "128": "assets/logo.png"
     },
     "permissions": [
         "storage"
+    ],
+    "host_permissions": [
+        "<all_urls>"
     ],
     "action": {
         "default_popup": "popup/popup.html"
@@ -15,7 +18,7 @@
     "content_scripts": [
         {
             "matches": [
-                "https://chatgpt.com/*"
+                "<all_urls>"
             ],
             "js": [
                 "content/content.js"
@@ -28,7 +31,6 @@
     "web_accessible_resources": [
         {
           "resources": ["assets/logo.png"],
-          "matches": ["https://chatgpt.com/*"]
+          "matches": ["<all_urls>"]
         }
-    ]
-}
+    ]}

--- a/src/features/content/index.tsx
+++ b/src/features/content/index.tsx
@@ -3,18 +3,25 @@ import { createRoot } from 'react-dom/client'
 import ContentContainer from './ContentContainer/ContentContainer.tsx'
 import './index.css'
 
-const contentRoot = document.createElement('div')
-contentRoot.id = 'content-root'
-document.body.appendChild(contentRoot)
+chrome.storage.local.get("enabledDomains", (result) => {
+  const domainList: string = result.enabledDomains || "chatgpt.com";
+  const domains = domainList.split(/[\n,\s]+/).filter(Boolean);
+  const allowed = domains.includes("*") || domains.some(d => location.hostname.includes(d));
+  if (!allowed) return;
 
-setTimeout(() => {
-  if (!document.querySelector("#content-root")) {
-    document.body.appendChild(contentRoot)
-  }
-}, 3000) // Incase some other extension removes ours
+  const contentRoot = document.createElement('div')
+  contentRoot.id = 'content-root'
+  document.body.appendChild(contentRoot)
 
-createRoot(contentRoot).render(
-  <StrictMode>
-      <ContentContainer />
-  </StrictMode>,
-)
+  setTimeout(() => {
+    if (!document.querySelector("#content-root")) {
+      document.body.appendChild(contentRoot)
+    }
+  }, 3000) // Incase some other extension removes ours
+
+  createRoot(contentRoot).render(
+    <StrictMode>
+        <ContentContainer />
+    </StrictMode>,
+  )
+})

--- a/src/features/popup/App.module.css
+++ b/src/features/popup/App.module.css
@@ -115,8 +115,17 @@ a {
 
     }
   }
+  & > .domains {
+    padding: 0.5rem 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    & > textarea {
+      width: 100%;
+      resize: vertical;
+    }
+  }
 }
 
 summary {
-  cursor: pointer;
-}
+  cursor: pointer;}

--- a/src/features/popup/App.tsx
+++ b/src/features/popup/App.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react'
 
 function App() {
   const [showButton, setShowButton] = useState(true)
+  const [domains, setDomains] = useState("chatgpt.com")
 
   function toggleShowButton(newValue: boolean) {
     setShowButton(newValue)
@@ -23,17 +24,20 @@ function App() {
 
 
   useEffect(() => {
-    chrome.storage.local.get("showButton", (result) => {
+    chrome.storage.local.get(["showButton", "enabledDomains"], (result) => {
       if (result.showButton !== undefined) {
         setShowButton(result.showButton);
+      }
+      if (result.enabledDomains !== undefined) {
+        setDomains(result.enabledDomains);
       }
     });
   }, []);
 
 
   useEffect(() => {
-    chrome.storage.local.set({ showButton: showButton });
-  }, [showButton]);
+    chrome.storage.local.set({ showButton: showButton, enabledDomains: domains });
+  }, [showButton, domains]);
 
 
   return (
@@ -93,6 +97,14 @@ function App() {
           // onChange={(e) => setShowButton(e.target.checked)}
           />
 
+        </div>
+        <div className={styles.domains}>
+          <label>Enabled domains (comma or newline separated, * for all)</label>
+          <textarea
+            value={domains}
+            onChange={(e) => setDomains(e.target.value)}
+            rows={3}
+          />
         </div>
       </div>
       <div className={styles.footer}>


### PR DESCRIPTION
## Summary
- make extension available for any domain
- add domain allow list input in popup
- only inject when current site is in user list
- update README usage instructions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e1a1c63e08327a429faf70315aacd