### PR TITLE
Add cross-site support for ScrollMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ I made this extension because I kept getting lost during my conversations with c
 
 2. Restart chrome
 
-3. Go to chatgpt, you should see a toggle button for the minimap in the top right corner. Open the minimap by pressing this button.
+3. Visit any website and enable ScrollMap from the extension popup. You can also enable it globally for all sites.
 
-4. Ask chatgpt a message and hit refresh minimap. A condensed view of the conversation should be shown in the minimap.
+4. Once enabled, click the minimap button that appears in the top right corner of the page to open the minimap.
 
 
 ## Performace improvement

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -15,7 +15,7 @@
     "content_scripts": [
         {
             "matches": [
-                "https://chatgpt.com/*"
+                "<all_urls>"
             ],
             "js": [
                 "content/content.js"
@@ -28,7 +28,6 @@
     "web_accessible_resources": [
         {
           "resources": ["assets/logo.png"],
-          "matches": ["https://chatgpt.com/*"]
+          "matches": ["<all_urls>"]
         }
-    ]
-}
+    ]}

--- a/src/features/content/ContentContainer/ContentContainer.tsx
+++ b/src/features/content/ContentContainer/ContentContainer.tsx
@@ -10,10 +10,23 @@ export default function ContentContainer() {
   const [currentUrl, setCurrentUrl] = useState<string>("")
   const [currentScrollContainer, setCurrentScrollContainer] = useState<HTMLElement|null>(null)
   const [showButton, setShowButton] = useState<boolean>(true)
+  const [enabled, setEnabled] = useState<boolean>(false)
 
   // functions
   function updateCurrentUrl() {
     setCurrentUrl(location.href)
+  }
+
+  function refreshSettings() {
+    const host = location.hostname
+    chrome.storage.local.get(["enableAll", "enabledHosts", "showButton"], (result) => {
+      const enableAll = result.enableAll || false
+      const hosts: string[] = result.enabledHosts || []
+      setEnabled(enableAll || hosts.includes(host))
+      if (result.showButton !== undefined) {
+        setShowButton(result.showButton)
+      }
+    });
   }
 
   function delay(milliseconds: number) {
@@ -21,6 +34,10 @@ export default function ContentContainer() {
   }
 
   async function searchForChat(): Promise<null> {
+    if (!enabled) {
+      setCurrentScrollContainer(null)
+      return null
+    }
     await delay(500)
     for (let i =0; i<10; i++) {
       const chat = queryChatContainer()
@@ -38,16 +55,13 @@ export default function ContentContainer() {
   useEffect(() => {
     const urlObserver = new MutationObserver(updateCurrentUrl)
     urlObserver.observe(document, {childList: true, subtree: true})
-    chrome.storage.local.get("showButton", (result) => {
-      if (result.showButton !== undefined) {
-        setShowButton(result.showButton);
-      }
-    });
+    refreshSettings()
   }, [])
 
   // On current url change
   useEffect(() => {
     // console.log("current url", currentUrl.slice(-2))
+    refreshSettings()
     searchForChat()
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUrl])

--- a/src/features/content/ContentContainer/Minimap/utils.ts
+++ b/src/features/content/ContentContainer/Minimap/utils.ts
@@ -146,6 +146,9 @@ export function queryChatContainer(): HTMLElement | null {
   if (firstChatMessage) {
     chatMessageContainer = firstChatMessage.parentElement;
   }
+  if (!chatMessageContainer) {
+    chatMessageContainer = document.scrollingElement as HTMLElement;
+  }
   return chatMessageContainer;
 }
 

--- a/src/features/popup/App.tsx
+++ b/src/features/popup/App.tsx
@@ -8,6 +8,9 @@ import { useEffect, useState } from 'react'
 
 function App() {
   const [showButton, setShowButton] = useState(true)
+  const [enableAll, setEnableAll] = useState(false)
+  const [enableSite, setEnableSite] = useState(false)
+  const [currentHost, setCurrentHost] = useState('')
 
   function toggleShowButton(newValue: boolean) {
     setShowButton(newValue)
@@ -23,17 +26,42 @@ function App() {
 
 
   useEffect(() => {
-    chrome.storage.local.get("showButton", (result) => {
-      if (result.showButton !== undefined) {
-        setShowButton(result.showButton);
-      }
-    });
-  }, []);
+    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+      const url = tabs[0].url ? new URL(tabs[0].url) : null
+      const host = url ? url.hostname : ''
+      setCurrentHost(host)
+      chrome.storage.local.get(["showButton", "enableAll", "enabledHosts"], (result) => {
+        if (result.showButton !== undefined) {
+          setShowButton(result.showButton)
+        }
+        const hosts: string[] = result.enabledHosts || []
+        setEnableAll(!!result.enableAll)
+        setEnableSite(hosts.includes(host))
+      })
+    })
+  }, [])
 
 
   useEffect(() => {
     chrome.storage.local.set({ showButton: showButton });
   }, [showButton]);
+
+  useEffect(() => {
+    chrome.storage.local.get(["enabledHosts"], (result) => {
+      const hosts: string[] = result.enabledHosts || []
+      const index = hosts.indexOf(currentHost)
+      if (enableSite && index === -1) {
+        hosts.push(currentHost)
+      } else if (!enableSite && index !== -1) {
+        hosts.splice(index, 1)
+      }
+      chrome.storage.local.set({ enabledHosts: hosts })
+    })
+  }, [enableSite, currentHost])
+
+  useEffect(() => {
+    chrome.storage.local.set({ enableAll: enableAll })
+  }, [enableAll])
 
 
   return (
@@ -46,12 +74,7 @@ function App() {
       <div className={styles.body}>
 
         <div>
-          This extension only works for <a
-            href="https://www.chatgpt.com"
-            target="_blank"
-          >
-            chatgpt.com
-          </a>
+          Enable ScrollMap on any website. Use the options below to control where it appears.
         </div>
 
         <div className={styles.demo}>
@@ -79,6 +102,37 @@ function App() {
         {/* <h3>
           Settings
         </h3> */}
+        <div
+          className={styles.checkbox}
+          onClick={() => setEnableAll(!enableAll)}
+        >
+          <label>
+            Enable on all sites
+          </label>
+
+          <input
+            type="checkbox"
+            checked={enableAll}
+          />
+
+        </div>
+
+        {!enableAll && (
+        <div
+          className={styles.checkbox}
+          onClick={() => setEnableSite(!enableSite)}
+        >
+          <label>
+            Enable on {currentHost || 'this site'}
+          </label>
+
+          <input
+            type="checkbox"
+            checked={enableSite}
+          />
+
+        </div>
+        )}
         <div
           className={styles.checkbox}
           onClick={() => toggleShowButton(!showButton)}


### PR DESCRIPTION
## Summary
- allow content scripts on all URLs
- add per-site/global enable settings in the popup
- load settings in content script and adjust behavior
- fallback to main page scroll element if chat container not found
- document new usage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e1a1c63e08327a429faf70315aacd