### PR TITLE
Enable minimap across websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ I made this extension because I kept getting lost during my conversations with c
 
 2. Restart chrome
 
-3. Go to chatgpt, you should see a toggle button for the minimap in the top right corner. Open the minimap by pressing this button.
+3. Navigate to any website in your allowed list (all sites are allowed by default). Use the popup to edit this list.
 
-4. Ask chatgpt a message and hit refresh minimap. A condensed view of the conversation should be shown in the minimap.
+4. On supported pages, you should see a toggle button for the minimap in the top right corner. Open the minimap by pressing this button.
+
+5. Ask chatgpt a message or scroll the page and hit refresh minimap. A condensed view of the conversation or page should be shown in the minimap.
 
 
 ## Performace improvement

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -15,7 +15,7 @@
     "content_scripts": [
         {
             "matches": [
-                "https://chatgpt.com/*"
+                "<all_urls>"
             ],
             "js": [
                 "content/content.js"
@@ -28,7 +28,6 @@
     "web_accessible_resources": [
         {
           "resources": ["assets/logo.png"],
-          "matches": ["https://chatgpt.com/*"]
+          "matches": ["<all_urls>"]
         }
-    ]
-}
+    ]}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,5 +4,5 @@ export const DEFAULT_OPTIONS: ExtensionOptions = {
     keepOpen: false,
     smoothScrolling: true,
     autoRefresh: false,
-    refreshPeriod: 10
-}
+    refreshPeriod: 10,
+    allowedHosts: ["*"]}

--- a/src/features/content/ContentContainer/ContentContainer.tsx
+++ b/src/features/content/ContentContainer/ContentContainer.tsx
@@ -10,6 +10,8 @@ export default function ContentContainer() {
   const [currentUrl, setCurrentUrl] = useState<string>("")
   const [currentScrollContainer, setCurrentScrollContainer] = useState<HTMLElement|null>(null)
   const [showButton, setShowButton] = useState<boolean>(true)
+  const [siteAllowed, setSiteAllowed] = useState<boolean>(true)
+  const [isFullHtml, setIsFullHtml] = useState<boolean>(false)
 
   // functions
   function updateCurrentUrl() {
@@ -26,11 +28,13 @@ export default function ContentContainer() {
       const chat = queryChatContainer()
       if (chat) {
           setCurrentScrollContainer(chat.parentElement)
+          setIsFullHtml(false)
           return null
       }
       await delay(300)
     }
-    setCurrentScrollContainer(null)
+    setCurrentScrollContainer(document.documentElement)
+    setIsFullHtml(true)
     return null
 }
 
@@ -38,24 +42,31 @@ export default function ContentContainer() {
   useEffect(() => {
     const urlObserver = new MutationObserver(updateCurrentUrl)
     urlObserver.observe(document, {childList: true, subtree: true})
-    chrome.storage.local.get("showButton", (result) => {
+    chrome.storage.local.get(["showButton", "allowedHosts"], (result) => {
       if (result.showButton !== undefined) {
         setShowButton(result.showButton);
       }
+      const hosts = Array.isArray(result.allowedHosts) ? result.allowedHosts as string[] : ["*"]
+      const hostname = location.hostname
+      const allowed = hosts.includes("*") || hosts.some(h => hostname.includes(h))
+      setSiteAllowed(allowed)
     });
   }, [])
 
   // On current url change
   useEffect(() => {
-    // console.log("current url", currentUrl.slice(-2))
-    searchForChat()
+    if (siteAllowed) {
+      searchForChat()
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUrl])
+  }, [currentUrl, siteAllowed])
 
   return (
  
       <div className={styles.appContainer}>
-        {showButton && <Minimap elementToMap={currentScrollContainer}/>}
+        {showButton && siteAllowed && (
+          <Minimap elementToMap={currentScrollContainer} isFullHtml={isFullHtml} />
+        )}
       </div>
 
   );

--- a/src/features/popup/App.module.css
+++ b/src/features/popup/App.module.css
@@ -115,8 +115,14 @@ a {
 
     }
   }
+  & textarea {
+    width: 100%;
+    margin-top: 0.5rem;
+    background-color: var(--background);
+    color: var(--text-color);
+    border: solid 1px var(--border-color);
+  }
 }
 
 summary {
-  cursor: pointer;
-}
+  cursor: pointer;}

--- a/src/features/popup/App.tsx
+++ b/src/features/popup/App.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react'
 
 function App() {
   const [showButton, setShowButton] = useState(true)
+  const [allowedHostsInput, setAllowedHostsInput] = useState("*")
 
   function toggleShowButton(newValue: boolean) {
     setShowButton(newValue)
@@ -23,9 +24,12 @@ function App() {
 
 
   useEffect(() => {
-    chrome.storage.local.get("showButton", (result) => {
+    chrome.storage.local.get(["showButton", "allowedHosts"], (result) => {
       if (result.showButton !== undefined) {
         setShowButton(result.showButton);
+      }
+      if (Array.isArray(result.allowedHosts)) {
+        setAllowedHostsInput(result.allowedHosts.join("\n"))
       }
     });
   }, []);
@@ -34,6 +38,11 @@ function App() {
   useEffect(() => {
     chrome.storage.local.set({ showButton: showButton });
   }, [showButton]);
+
+  useEffect(() => {
+    const hosts = allowedHostsInput.split(/\n+/).map(s => s.trim()).filter(Boolean)
+    chrome.storage.local.set({ allowedHosts: hosts })
+  }, [allowedHostsInput])
 
 
   return (
@@ -46,12 +55,7 @@ function App() {
       <div className={styles.body}>
 
         <div>
-          This extension only works for <a
-            href="https://www.chatgpt.com"
-            target="_blank"
-          >
-            chatgpt.com
-          </a>
+          Specify the websites where the minimap should appear below.
         </div>
 
         <div className={styles.demo}>
@@ -93,6 +97,16 @@ function App() {
           // onChange={(e) => setShowButton(e.target.checked)}
           />
 
+        </div>
+        <div className={styles.checkbox}>
+          <label>
+            Allowed websites
+          </label>
+          <textarea
+            className={styles.textarea}
+            value={allowedHostsInput}
+            onChange={(e) => setAllowedHostsInput(e.target.value)}
+          />
         </div>
       </div>
       <div className={styles.footer}>

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -2,5 +2,5 @@ export interface ExtensionOptions {
     keepOpen: boolean,
     smoothScrolling: boolean,
     autoRefresh: boolean,
-    refreshPeriod: number
-}
+    refreshPeriod: number,
+    allowedHosts: string[]}


### PR DESCRIPTION
## Summary
- allow running content script on all URLs
- configure allowed websites from the popup
- fallback to full-page minimap when not on ChatGPT
- update README usage instructions

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686e1a1c63e08327a429faf70315aacd