### PR TITLE
Improve DOM watcher efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Before (1.2) | After (1.3)
 -|-
 <video src="https://github.com/user-attachments/assets/64cdde2a-daa2-4a67-88da-a4d24e76beb2.mp4"> |  <video src="https://github.com/user-attachments/assets/b6f49f82-7ea3-4e80-8644-9dae603fbf91.mp4">
 
+### 1.4 Debounced DOM observation
+The minimap now batches DOM mutations before redrawing which significantly reduces CPU usage when ChatGPT is producing long answers.
+
 
 <details>
  

--- a/src/features/content/ContentContainer/Minimap/Minimap.tsx
+++ b/src/features/content/ContentContainer/Minimap/Minimap.tsx
@@ -86,7 +86,7 @@ const Minimap = (
   useEffect(() => {
     if (!elementToMap) return
     console.log("observers attached!")
-    const childObserver = createChildObserver(elementToMap, handleQueueRedraw)
+    const childObserver = createChildObserver(elementToMap, handleQueueRedraw, 500)
     const sizeObserver = createSizeObserver(elementToMap, handleQueueRedraw)
     return () => {
       console.log("observers disconnected!")

--- a/src/features/content/ContentContainer/Minimap/utils.ts
+++ b/src/features/content/ContentContainer/Minimap/utils.ts
@@ -58,8 +58,20 @@ export function elementObserver(
  */
 export function createChildObserver(
   elementToObserve: HTMLElement,
-  callback: CallableFunction
+  callback: CallableFunction,
+  debounceTime = 300
 ): MutationObserver {
+  let timeoutId: number | undefined
+  const debouncedCallback = () => {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId)
+    }
+    timeoutId = window.setTimeout(() => {
+      callback()
+      timeoutId = undefined
+    }, debounceTime)
+  }
+
   const mutationObserver = new MutationObserver(function (mutations) {
     const minimapComponent = document.querySelector("#minimap-component")
     if (!minimapComponent) return
@@ -73,8 +85,8 @@ export function createChildObserver(
         return
       }
 
-      callback()
-      console.log(mutation);
+      debouncedCallback()
+      console.log(mutation)
     });
   });
 


### PR DESCRIPTION
## Summary
- debounce DOM mutations before redrawing the minimap
- pass debounce interval to observer
- document new behaviour in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687402a260b88327a39e4be2879139eb