### PR TITLE
Introduce polling to lower DOM observation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Before (1.2) | After (1.3)
 <video src="https://github.com/user-attachments/assets/64cdde2a-daa2-4a67-88da-a4d24e76beb2.mp4"> |  <video src="https://github.com/user-attachments/assets/b6f49f82-7ea3-4e80-8644-9dae603fbf91.mp4">
 
 
+### Reduced DOM observation
+Version 1.4 replaces the heavy `MutationObserver` logic with a lightweight polling
+approach. The extension now checks for new chat messages every couple seconds
+instead of monitoring every DOM mutation. This significantly reduces CPU usage
+while keeping the minimap up to date.
+
 <details>
  
 <summary> <h2>React learning notes</h2></summary>

--- a/src/features/content/ContentContainer/Minimap/Minimap.tsx
+++ b/src/features/content/ContentContainer/Minimap/Minimap.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import styles from "./Minimap.module.css"
 import Slider from "./Slider/Slider";
 import MinimapCanvas from "./MinimapCanvas/MinimapCanvas";
-import { createChildObserver, createSizeObserver, onNextChat, onPreviousChat } from "./utils";
+import { createSizeObserver, onNextChat, onPreviousChat } from "./utils";
+import usePollingObserver from "./usePollingObserver";
 import { BiLeftArrow, BiRefresh, BiRightArrow,  } from "react-icons/bi";
 import { VscLoading } from "react-icons/vsc";
 import { CgClose } from "react-icons/cg";
@@ -82,18 +83,19 @@ const Minimap = (
 
 
 
-  // Add observers to look for changes in elementToMap and queue a redraw
+  // Observe size changes and poll for new messages to queue redraws
   useEffect(() => {
     if (!elementToMap) return
     console.log("observers attached!")
-    const childObserver = createChildObserver(elementToMap, handleQueueRedraw)
     const sizeObserver = createSizeObserver(elementToMap, handleQueueRedraw)
     return () => {
       console.log("observers disconnected!")
-      childObserver.disconnect();
       sizeObserver.disconnect()
-    };
+    }
   }, [elementToMap])
+
+  // Poll for chat updates instead of using a MutationObserver
+  usePollingObserver(elementToMap, handleQueueRedraw, 2000)
 
 
   // Add event listeners to listen to scroll events of elementToMap

--- a/src/features/content/ContentContainer/Minimap/usePollingObserver.ts
+++ b/src/features/content/ContentContainer/Minimap/usePollingObserver.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Periodically checks the number of chat messages in `elementToObserve` and
+ * triggers `callback` when the count changes. This avoids continuous
+ * MutationObserver updates and reduces resource usage.
+ *
+ * @param elementToObserve - Container element holding chat messages.
+ * @param callback - Function invoked when the element's message count changes.
+ * @param intervalMs - Polling interval in milliseconds.
+ */
+export default function usePollingObserver(
+  elementToObserve: HTMLElement | null,
+  callback: CallableFunction,
+  intervalMs: number = 1000,
+): void {
+  const previousCount = useRef<number>(0)
+
+  useEffect(() => {
+    if (!elementToObserve) return
+
+    const checkForChanges = () => {
+      const count = elementToObserve.querySelectorAll('[data-message-author-role]').length
+      if (count !== previousCount.current) {
+        previousCount.current = count
+        callback()
+      }
+    }
+
+    // Initial check and then periodic polling
+    checkForChanges()
+    const id = setInterval(checkForChanges, intervalMs)
+    return () => clearInterval(id)
+  }, [elementToObserve, callback, intervalMs])
+}


### PR DESCRIPTION
## Summary
- poll for new chat messages to avoid expensive mutation observers
- document the new polling behaviour

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687402a260b88327a39e4be2879139eb